### PR TITLE
Add develop bundles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ script:
 - ./operator-index.py build -vvvv --tag-extension dev
 deploy:
 - provider: script
-  script: docker login -u "$QUAY_USERNAME" -p "$QUAY_PASSWORD" quay.io && ./operator-index.py push -vvvv --tag-extension dev --extra-tag develop
+  script: docker login -u "$QUAY_USERNAME" -p "$QUAY_PASSWORD" quay.io && ./operator-index.py push -vvvv --tag-extension dev --extra-tag develop && ./operator-index.py push -vvvv --testing
   on:
     branch: develop
 - provider: script


### PR DESCRIPTION
This is to let us use the "testing" tag on quay.io to point to operators on their "develop" tag based on the bundles that had their CSVs scraped at the time of bundling.

The current state of index releases:
  * Versioned tags for releases on the `main` branch
  * `latest` tag for releases on the `main` branch
  * Versioned but `-dev` extended tags for releases on the `develop` branch
  * `develop` tag for releases on the `develop` branch
_All of which will point to the pinned operator bundle versions from operator-index.yml at the time they were built_.

This PR adds one other index release:
  * `testing` tag for releases from the `develop` branch of the index, with all bundle CSVs derived from the published bundles tagged `develop` instead of their pinned versions from `operator-index.yml`.

This means that if you're testing OLM-specific things from an operator, instead of locally building a custom bundle you should be able to:
  * Get your operator code merged into the operators' `develop` branch.
  * Wait for CD on the `develop` branch of that operator to push its normal images
  * Trigger a manual rebuild of this index on its own `develop` branch _after_ that `develop` branch has successfully deployed the bundles to quay.io
  * Use a CatalogSource with the `testing` tag instead of the normal versioned/`latest`/`develop`. You could set this [here](https://github.com/RedHatGov/devsecops-workshop-code/blob/ecb1b902f23b29ed614be78a61655436e7b9c8f6/vars/devsecops.example.yml#L63) for example in the DevSecOps workshop.