### PR TITLE
Pin OPM version throughout CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,17 +3,20 @@ dist: bionic
 language: python
 services:
 - docker
+env:
+  global:
+    - OPM_VERSION=1.14.0
 install:
 - pip3 install -r requirements.txt
 script:
 # Don't even accidentally build a copy without appending -dev
-- ./operator-index.py build -vvvv --tag-extension dev
+- ./operator-index.py build -vvvv --tag-extension dev --opm-version $OPM_VERSION
 deploy:
 - provider: script
-  script: docker login -u "$QUAY_USERNAME" -p "$QUAY_PASSWORD" quay.io && ./operator-index.py push -vvvv --tag-extension dev --extra-tag develop && ./operator-index.py push -vvvv --testing
+  script: docker login -u "$QUAY_USERNAME" -p "$QUAY_PASSWORD" quay.io && ./operator-index.py push -vvvv --tag-extension dev --extra-tag develop --opm-version $OPM_VERSION && ./operator-index.py push -vvvv --testing --opm-version $OPM_VERSION
   on:
     branch: develop
 - provider: script
-  script: docker login -u "$QUAY_USERNAME" -p "$QUAY_PASSWORD" quay.io && ./operator-index.py push -vvvv --extra-tag latest --build
+  script: docker login -u "$QUAY_USERNAME" -p "$QUAY_PASSWORD" quay.io && ./operator-index.py push -vvvv --extra-tag latest --build --opm-version $OPM_VERSION
   on:
     branch: main

--- a/operator-index.py
+++ b/operator-index.py
@@ -271,6 +271,21 @@ def tag_extension_opt(func):
     )(func)
 
 
+def opm_version_opt(func):
+    return click.option(
+        "-o", "--opm-version", default="latest",
+        help="The version of OPM to use to build the index."
+    )(func)
+
+
+def testing_opt(func):
+    return click.option(
+        "--testing", is_flag=True,
+        help=("Convert all bundled operators to the 'develop' tag "
+              "and build an index tag named 'testing' instead.")
+    )(func)
+
+
 @click.group(invoke_without_command=True)
 @verbose_opt
 @click.version_option()
@@ -286,11 +301,8 @@ def main(verbose):
 @main.command(name="build")
 @verbose_opt
 @tag_extension_opt
-@click.option("-o", "--opm-version", default="latest",
-              help="The version of OPM to use to build the index.")
-@click.option("--testing", is_flag=True,
-              help=("Convert all bundled operators to the 'develop' tag "
-                    "and build an index tag named 'testing' instead."))
+@opm_version_opt
+@testing_opt
 def do_build(verbose, tag_extension, opm_version, testing):
     """
     Builds the image locally
@@ -322,11 +334,10 @@ def do_build(verbose, tag_extension, opm_version, testing):
 @click.option("--build/--no-build", default=True,
               help=("Whether to build the images if they don't exist "
                     "(default: build)."))
-@click.option("--testing", is_flag=True,
-              help=("If building, convert all bundles to the 'develop' tag "
-                    "and push an index tag named 'testing' instead."))
+@opm_version_opt
+@testing_opt
 @click.pass_context
-def push(ctx, verbose, tag_extension, extra_tag, build, testing):
+def push(ctx, verbose, tag_extension, extra_tag, build, opm_version, testing):
     """
     Pushes the image with the appropriate tags to the registry
     """
@@ -385,7 +396,7 @@ def push(ctx, verbose, tag_extension, extra_tag, build, testing):
             #   and set the index tag to 'testing'
             ctx.invoke(do_build, verbose=verbose,
                        tag_extension=tag_extension,
-                       opm_version="latest",
+                       opm_version=opm_version,
                        testing=testing)
         else:  # the user doesn't want to build a new version and it's not here
             raise RuntimeError("Unable to find the appropriate image to push.")

--- a/operator-index.py
+++ b/operator-index.py
@@ -225,7 +225,7 @@ def install_opm(version: str = "latest") -> None:
         version = str(latest_opm)
         logger.debug("Identified latest version as: {}".format(version))
 
-    if not os.path.exists(config["opm_path"] + "-" + str(latest_opm)):
+    if not os.path.exists(config["opm_path"] + "-" + version):
         logger.debug("Downloading {}".format(
             config["opm_url"] + version + "/linux-amd64-opm"
         ))


### PR DESCRIPTION
Reduced some redundancy in script by consolidating click options, used Travis global env to set OPM version to prevent rate limiting at the GitHub unauthenticated API.

fixes #9 